### PR TITLE
Find dom node is deprecated

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,9 +5,7 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
 ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+    <App />,
   document.getElementById("root")
 );
 


### PR DESCRIPTION
Pressing login button throws this error 
![Screen Shot 2021-08-25 at 11 07 48 am](https://user-images.githubusercontent.com/17758148/130709789-f94386a8-9ec8-4ead-9315-a26500195073.png)
It also shows up at startup.

This is the only fix I could find as per https://stackoverflow.com/questions/61937037/how-can-i-fix-finddomnode-is-deprecated-in-strictmode-error

Let me know if there are any other ways we can resolve this error, because I'm not sure about removing strict